### PR TITLE
Improve timeline layout and update hero headline

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -26,7 +26,7 @@ export default function Home() {
               "@type": "Person",
               "name": "Mikhail Dziubenko",
               "jobTitle": "Aviation SME & Tech Lead",
-              "description": "AI & Crypto Enthusiast | Vibe Developer | Aviation SME | Instruction Design Wizard | Seasoned Team Lead & Mentor",
+              "description": "AI & Crypto Enthusiast | AI Agentic Developer | Aviation SME | Instruction Design Wizard | Seasoned Team Lead & Mentor | Expert in Crisis Management",
               "url": "https://mikhail.vercel.app/",
               "sameAs": [
                 "https://x.com/fiboboy",
@@ -147,7 +147,7 @@ export default function Home() {
               className="text-4xl md:text-5xl lg:text-6xl font-bold text-white mt-16 mb-4 mx-auto block"
             />
             <p className="text-lg md:text-xl text-neutral-400 max-w-2xl mb-8 mx-auto">
-              AI & Crypto Enthusiast | Vibe Developer | Aviation SME | Instruction Design Wizard | Seasoned Team Lead & Mentor
+              AI & Crypto Enthusiast | AI Agentic Developer | Aviation SME | Instruction Design Wizard | Seasoned Team Lead & Mentor | Expert in Crisis Management
               <br />
               <span className="text-neutral-500 text-base md:text-lg">🌍 Curiosity-Driven Tech Explorer</span>
             </p>

--- a/web/src/components/ui/timeline/DesktopTimeline.tsx
+++ b/web/src/components/ui/timeline/DesktopTimeline.tsx
@@ -161,7 +161,7 @@ export function DesktopTimeline({
                   key={index}
                   className="absolute w-[calc(100%-2rem)]"
                   style={{
-                    top: `${item.basePosition}px`,
+                    top: `${item.basePosition + item.verticalShift}px`,
                     height: `${item.height}px`,
                     transition: 'all 0.5s cubic-bezier(0.4, 0, 0.2, 1)',
                     transform: `translateX(-20px)`,
@@ -215,7 +215,7 @@ export function DesktopTimeline({
                   key={index}
                   className="absolute w-[calc(100%-2rem)]"
                   style={{
-                    top: `${item.basePosition}px`,
+                    top: `${item.basePosition + item.verticalShift}px`,
                     height: `${item.height}px`,
                     transition: 'all 0.5s cubic-bezier(0.4, 0, 0.2, 1)',
                     transform: `translateX(20px)`,


### PR DESCRIPTION
## Summary
- update the hero JSON-LD and tagline to highlight the AI agentic developer and crisis management expertise
- cascade overlapping timeline cards with vertical spacing and adjusted container heights so items remain clickable
- apply the computed vertical shift when positioning desktop timeline cards to prevent hidden items while preserving the visual style

## Testing
- npm run lint *(fails: `next` command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e21762e810832185f48acaca596c9e