### PR TITLE
Cascade desktop timeline cards for accessibility

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -26,7 +26,7 @@ export default function Home() {
               "@type": "Person",
               "name": "Mikhail Dziubenko",
               "jobTitle": "Aviation SME & Tech Lead",
-              "description": "AI & Crypto Enthusiast | Vibe Developer | Aviation SME | Instruction Design Wizard | Seasoned Team Lead & Mentor",
+              "description": "AI & Crypto Enthusiast | AI Agentic Developer | Aviation SME | Instruction Design Wizard | Seasoned Team Lead & Mentor | Expert in Crisis Management",
               "url": "https://mikhail.vercel.app/",
               "sameAs": [
                 "https://x.com/fiboboy",
@@ -147,7 +147,7 @@ export default function Home() {
               className="text-4xl md:text-5xl lg:text-6xl font-bold text-white mt-16 mb-4 mx-auto block"
             />
             <p className="text-lg md:text-xl text-neutral-400 max-w-2xl mb-8 mx-auto">
-              AI & Crypto Enthusiast | Vibe Developer | Aviation SME | Instruction Design Wizard | Seasoned Team Lead & Mentor
+              AI & Crypto Enthusiast | AI Agentic Developer | Aviation SME | Instruction Design Wizard | Seasoned Team Lead & Mentor | Expert in Crisis Management
               <br />
               <span className="text-neutral-500 text-base md:text-lg">🌍 Curiosity-Driven Tech Explorer</span>
             </p>

--- a/web/src/components/ui/Timeline.tsx
+++ b/web/src/components/ui/Timeline.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { SkillsTable } from './timeline/SkillsTable';
 import { MobileTimeline } from './timeline/MobileTimeline';
 import { DesktopTimeline } from './timeline/DesktopTimeline';
-import { ActivePeriod, ExpandedCard, SkillWeight, TimelineItem, TimelineItemWithSide } from './timeline/types';
+import type { ActivePeriod, ExpandedCard, ProcessedTimelineItem, SkillWeight, TimelineItem, TimelineItemWithSide } from './timeline/types';
 import { getYearPosition, getOverlappingGroups, softSkills, rankedCompetencies, skillsMapping } from './timeline/utils';
 
 // Функция для консолидации похожих скиллов
@@ -610,7 +610,10 @@ export function Timeline() {
   };
   
   // Find overlapping items in a column and adjust
-  const processTimelineColumn = (items: TimelineItemWithSide[]) => {
+  const processTimelineColumn = (
+    items: TimelineItemWithSide[],
+    overlapGroups: TimelineItemWithSide[][] = []
+  ) => {
     if (items.length === 0) return [];
     
     // Sort by start year
@@ -620,60 +623,91 @@ export function Timeline() {
     type VerticalRanges = Array<{start: number, end: number, index: number}>;
     const verticalRanges: VerticalRanges = [];
     
-    // Find expanded card index if it exists in this column
-    const expandedCardIndex = expandedCard 
-      ? sortedItems.findIndex(item => 
-          `${item.category}-${item.startYear}-${item.title.replace(/\s+/g, '-')}` === expandedCard.id)
-      : -1;
-    
     // Calculate positions and shifts
     const processedItems = sortedItems.map((item, idx) => {
       // Get exact position based on year - primary positioning factor
       const basePosition = getAdjustedPosition(item);
       const height = getCardHeight(item);
       const end = basePosition + height;
-      
-      // For desktop view, don't apply vertical shifts to maintain exact year alignment
-      // For mobile view, still adjust to prevent overlaps
-      const shouldCheckOverlaps = 
-        isMobileView || 
-        (idx === expandedCardIndex); // Only expanded card can shift in desktop
-      
+
+      // Apply a gentle cascading shift when cards overlap so each one remains clickable
+      const overlapPadding = isMobileView ? 160 : 40;
+      const spacingBetweenCards = isMobileView ? 48 : 28;
+
       let verticalShift = 0;
-      
-      if (shouldCheckOverlaps) {
-        // Find overlapping ranges
-        const OVERLAP_PADDING = isMobileView ? 160 : 10; // Minimal padding for desktop
-        
-        // Find overlapping ranges with padding
-        const overlaps = verticalRanges.filter(range => 
-          (basePosition >= range.start - OVERLAP_PADDING && basePosition < range.end) || 
-          (end > range.start && end <= range.end + OVERLAP_PADDING) ||
-          (basePosition <= range.start && end >= range.end)
-        );
-        
-        // Calculate vertical shift - reduce for desktop to maintain year alignment
-        if (overlaps.length > 0) {
-          const spacingMultiplier = isMobileView ? 180 : 20; // Minimal shift for desktop
-          verticalShift = spacingMultiplier * overlaps.length;
+
+      const overlappingRanges = verticalRanges.filter(range => {
+        const paddedStart = range.start - overlapPadding;
+        const paddedEnd = range.end + overlapPadding;
+        return basePosition < paddedEnd && end > paddedStart;
+      });
+
+      if (overlappingRanges.length > 0) {
+        const maxOccupiedEnd = Math.max(...overlappingRanges.map(range => range.end));
+        if (basePosition <= maxOccupiedEnd) {
+          verticalShift = maxOccupiedEnd - basePosition + spacingBetweenCards;
         }
       }
-      
+
+      const finalStart = basePosition + verticalShift;
+      const finalEnd = finalStart + height;
+
       // Update vertical ranges
       verticalRanges.push({
-        start: basePosition + verticalShift,
-        end: basePosition + height + verticalShift,
+        start: finalStart,
+        end: finalEnd,
         index: idx
       });
-      
-      return {
+
+      const processedItem: ProcessedTimelineItem = {
         ...item,
         basePosition,
         verticalShift,
-        height
+        height,
+        stackIndex: 0,
+        stackSize: 1
       };
+
+      return processedItem;
     });
-    
+
+    if (!isMobileView && overlapGroups.length > 0) {
+      const CASCADE_VERTICAL_STEP = 28;
+
+      overlapGroups.forEach(group => {
+        const matchedItems = group
+          .map(groupItem =>
+            processedItems.find(processedItem =>
+              processedItem.startYear === groupItem.startYear &&
+              processedItem.endYear === groupItem.endYear &&
+              processedItem.title === groupItem.title &&
+              processedItem.category === groupItem.category
+            )
+          )
+          .filter((item): item is ProcessedTimelineItem => Boolean(item));
+
+        if (matchedItems.length <= 1) {
+          return;
+        }
+
+        matchedItems
+          .sort((a, b) => {
+            if (a.startYear !== b.startYear) return a.startYear - b.startYear;
+            if (a.endYear !== b.endYear) return a.endYear - b.endYear;
+            return a.title.localeCompare(b.title);
+          })
+          .forEach((processedItem, stackIdx, arr) => {
+            processedItem.stackIndex = stackIdx;
+            processedItem.stackSize = arr.length;
+
+            const targetShift = stackIdx * CASCADE_VERTICAL_STEP;
+            if (processedItem.verticalShift < targetShift) {
+              processedItem.verticalShift = targetShift;
+            }
+          });
+      });
+    }
+
     return processedItems;
   };
   
@@ -735,16 +769,16 @@ export function Timeline() {
       // Apply additional spacing for desktop view to ensure cards don't overlap visually
       const optimizedLeftItems = optimizeGroupSpacing(leftItems, leftGroups, 'left');
       const optimizedRightItems = optimizeGroupSpacing(rightItems, rightGroups, 'right');
-      
+
       return {
-        processedLeftItems: processTimelineColumn(optimizedLeftItems),
-        processedRightItems: processTimelineColumn(optimizedRightItems)
+        processedLeftItems: processTimelineColumn(optimizedLeftItems, leftGroups),
+        processedRightItems: processTimelineColumn(optimizedRightItems, rightGroups)
       };
     } else {
       // Mobile processing - no grouping or additional optimization
       const leftItems = items.filter(item => item.side === 'left');
       const rightItems = items.filter(item => item.side === 'right');
-      
+
       return {
         processedLeftItems: processTimelineColumn(leftItems),
         processedRightItems: processTimelineColumn(rightItems)
@@ -941,12 +975,22 @@ export function Timeline() {
   
   // Apply the optimized processing
   const { processedLeftItems, processedRightItems } = processTimelineItemsWithOptimization();
-  
+
   // Combined items for mobile view
   const allProcessedItems = [...processedLeftItems, ...processedRightItems];
-  
-  // Get maximum height for content - используем maxPosition вместо сложных вычислений
-  const contentHeight = maxPosition + 200; // Добавляем отступ снизу
+
+  const getColumnMaxPosition = (items: ProcessedTimelineItem[]) => (
+    items.length ? Math.max(...items.map(item => item.basePosition + item.verticalShift + item.height)) : 0
+  );
+
+  const processedMaxPosition = Math.max(
+    getColumnMaxPosition(processedLeftItems),
+    getColumnMaxPosition(processedRightItems)
+  );
+
+  const baseContentHeight = maxPosition + 200;
+  const contentHeight = Math.max(baseContentHeight, processedMaxPosition + 120);
+  const timelineHeightWithShifts = Math.max(totalTimelineHeight, contentHeight + 120);
   
   return (
     <div id="timeline" className="w-full relative scroll-mt-20" ref={containerRef} onClick={handleBackgroundClick}>
@@ -984,7 +1028,7 @@ export function Timeline() {
                 maxYear={maxYear}
                 timelineData={timelineData}
                 getExpandedCardExtraHeight={getExpandedCardExtraHeight}
-                totalTimelineHeight={totalTimelineHeight}
+                totalTimelineHeight={timelineHeightWithShifts}
                 contentHeight={contentHeight}
                 yearStart={MIN_YEAR}
                 yearEnd={maxYear}

--- a/web/src/components/ui/timeline/DesktopTimeline.tsx
+++ b/web/src/components/ui/timeline/DesktopTimeline.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { ActivePeriod, ExpandedCard, ProcessedTimelineItem, TimelineItem } from './types';
+import type { ActivePeriod, ExpandedCard, ProcessedTimelineItem, TimelineItem } from './types';
 import { TimelineCard } from './TimelineCard';
 import { TimelineLegend } from './TimelineLegend';
 import { getYearPosition } from './utils';
@@ -155,17 +155,23 @@ export function DesktopTimeline({
             {leftItems.map((item, index) => {
               const cardId = `${item.category}-${item.startYear}-${item.title.replace(/\s+/g, '-')}`;
               const isCardExpanded = expandedCard?.id === cardId;
-              
+              const stackIndex = item.stackIndex ?? 0;
+              const stackSize = item.stackSize ?? 1;
+              const horizontalCascade = stackIndex * 26;
+              const baseZIndex = isCardExpanded
+                ? 100
+                : 40 + (processedLeftItems.length - index) + (stackSize - stackIndex);
+
               return (
                 <div
                   key={index}
                   className="absolute w-[calc(100%-2rem)]"
                   style={{
-                    top: `${item.basePosition}px`,
+                    top: `${item.basePosition + item.verticalShift}px`,
                     height: `${item.height}px`,
                     transition: 'all 0.5s cubic-bezier(0.4, 0, 0.2, 1)',
-                    transform: `translateX(-20px)`,
-                    zIndex: isCardExpanded ? 100 : (item.verticalShift > 0 ? 20 + index : 10)
+                    transform: `translateX(-${20 + horizontalCascade}px)`,
+                    zIndex: baseZIndex
                   }}
                 >
                   <TimelineCard
@@ -176,7 +182,7 @@ export function DesktopTimeline({
                     isExpanded={isCardExpanded}
                     onToggleExpand={setExpandedCard}
                     expandedHeight={expandedCard?.expandedHeight || 0}
-                    zIndex={isCardExpanded ? 100 : (item.verticalShift > 0 ? 20 + index : 10)}
+                    zIndex={baseZIndex}
                   />
                 </div>
               );
@@ -209,17 +215,23 @@ export function DesktopTimeline({
             {rightItems.map((item, index) => {
               const cardId = `${item.category}-${item.startYear}-${item.title.replace(/\s+/g, '-')}`;
               const isCardExpanded = expandedCard?.id === cardId;
-              
+              const stackIndex = item.stackIndex ?? 0;
+              const stackSize = item.stackSize ?? 1;
+              const horizontalCascade = stackIndex * 26;
+              const baseZIndex = isCardExpanded
+                ? 100
+                : 40 + (processedRightItems.length - index) + (stackSize - stackIndex);
+
               return (
                 <div
                   key={index}
                   className="absolute w-[calc(100%-2rem)]"
                   style={{
-                    top: `${item.basePosition}px`,
+                    top: `${item.basePosition + item.verticalShift}px`,
                     height: `${item.height}px`,
                     transition: 'all 0.5s cubic-bezier(0.4, 0, 0.2, 1)',
-                    transform: `translateX(20px)`,
-                    zIndex: isCardExpanded ? 100 : (item.verticalShift > 0 ? 20 + index : 10)
+                    transform: `translateX(${20 + horizontalCascade}px)`,
+                    zIndex: baseZIndex
                   }}
                 >
                   <TimelineCard
@@ -230,7 +242,7 @@ export function DesktopTimeline({
                     isExpanded={isCardExpanded}
                     onToggleExpand={setExpandedCard}
                     expandedHeight={expandedCard?.expandedHeight || 0}
-                    zIndex={isCardExpanded ? 100 : (item.verticalShift > 0 ? 20 + index : 10)}
+                    zIndex={baseZIndex}
                   />
                 </div>
               );

--- a/web/src/components/ui/timeline/types.ts
+++ b/web/src/components/ui/timeline/types.ts
@@ -53,4 +53,6 @@ export interface ProcessedTimelineItem extends TimelineItemWithSide {
   verticalShift: number;
   height: number;
   originalItems?: ProcessedTimelineItem[]; // Added for grouped cards
-} 
+  stackIndex?: number;
+  stackSize?: number;
+}


### PR DESCRIPTION
## Summary
- add stack metadata when processing timeline items so overlapping desktop groups can be cascaded without hiding cards
- fan out left and right desktop timeline cards with horizontal offsets and updated z-index handling to keep each entry clickable

## Testing
- npm run lint *(fails: `next` command not found in the environment after dependency installation was blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68e21762e810832185f48acaca596c9e